### PR TITLE
Add Cloud/Self-hosted modes with API key auth to extension

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -11,7 +11,7 @@ let pendingUpdates = [];
 
 chrome.runtime.onInstalled.addListener(() => {
   console.log('Woolball extension installed');
-  
+
   chrome.storage.local.get(['clientId'], (result) => {
     if (!result.clientId) {
       clientId = generateClientId();
@@ -21,7 +21,7 @@ chrome.runtime.onInstalled.addListener(() => {
     }
     console.log('Client ID:', clientId);
   });
-  
+
   loadPendingUpdates();
 });
 
@@ -42,13 +42,13 @@ function loadPendingUpdates() {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === 'initWoolball') {
     initializeWoolball(sendResponse);
-    return true; 
+    return true;
   } else if (message.action === 'connect') {
     if (!isWoolballInitialized) {
-      sendResponse({ success: false, error: 'Woolball not initialized. Click "Initialize Woolball" first.' });
+      sendResponse({ success: false, error: 'Woolball not initialized.' });
     } else {
-      connectToServer(message.serverUrl, sendResponse);
-      return true; 
+      connectToServer(message.serverUrl, message.apiKey, sendResponse);
+      return true;
     }
   } else if (message.action === 'disconnect') {
     disconnectFromServer();
@@ -56,9 +56,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   } else if (message.action === 'getWoolballStatus') {
     sendResponse({ initialized: isWoolballInitialized, connected: isConnected });
   } else if (message.action === 'getPendingUpdates') {
-    const updates = [...pendingUpdates]; 
+    const updates = [...pendingUpdates];
     sendResponse({ updates });
-    
+
     pendingUpdates = [];
     chrome.storage.local.set({ pendingUpdates: [] });
     console.log(`Sent ${updates.length} pending updates to popup`);
@@ -69,12 +69,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 async function initializeWoolball(sendResponse) {
   try {
     console.log('Initializing Woolball client...');
-    
+
     if (woolballClient) {
       console.log('Disconnecting existing client...');
       disconnectFromServer();
     }
-    
+
     if (!clientId) {
       console.log('Loading client ID from storage...');
       const result = await chrome.storage.local.get(['clientId']);
@@ -82,22 +82,18 @@ async function initializeWoolball(sendResponse) {
       chrome.storage.local.set({ clientId });
       console.log('Using client ID:', clientId);
     }
-    
+
     console.log('Importing Woolball...');
-    
-    if (typeof document === 'undefined') {
-      console.log('Service worker environment detected');
-    }
-    
+
     woolballClient = new Woolball(clientId, null, {
       environment: 'extension'
     });
-    
+
     console.log('Woolball client created successfully');
     isWoolballInitialized = true;
-    
+
     sendResponse({ success: true });
-    
+
     console.log('Woolball initialized successfully');
   } catch (error) {
     console.error('Error initializing Woolball:', error);
@@ -106,29 +102,41 @@ async function initializeWoolball(sendResponse) {
   }
 }
 
-async function connectToServer(serverUrl, sendResponse) {
+async function connectToServer(serverUrl, apiKey, sendResponse) {
   try {
     console.log('Connecting to server:', serverUrl);
-    
+
     if (!woolballClient) {
-      sendResponse({ success: false, error: 'Woolball client not initialized. Click "Initialize Woolball" first.' });
+      sendResponse({ success: false, error: 'Woolball client not initialized.' });
       return;
     }
-    
+
     try {
-      woolballClient.wsUrl = serverUrl;
-      
+      // When an API key is provided, we need to recreate the Woolball instance
+      // with the key embedded in the clientId as a query param, since clientId
+      // is immutable after construction
+      if (apiKey) {
+        woolballClient.destroy();
+        const wsClientId = `${clientId}?key=${apiKey}`;
+        woolballClient = new Woolball(wsClientId, null, {
+          environment: 'extension'
+        });
+        isWoolballInitialized = true;
+      }
+
+      woolballClient.setWsUrl(serverUrl);
+
       console.log('Starting connection...');
       woolballClient.start();
-      
+
       console.log('Woolball client started successfully');
-      
+
       setupEventListeners();
-      
+
       isConnected = true;
-      
+
       sendResponse({ success: true });
-      
+
       console.log(`Successfully connected to Woolball server at ${serverUrl}`);
     } catch (woolballError) {
       console.error('Woolball connection error:', woolballError);
@@ -148,7 +156,7 @@ function disconnectFromServer() {
       woolballClient.destroy();
       isConnected = false;
       console.log('Disconnected from server');
-      
+
       notifyPopup('connectionStatus', { connected: false });
     } catch (error) {
       console.error('Error disconnecting from server:', error);
@@ -163,7 +171,7 @@ function setupEventListeners() {
   }
 
   console.log('Setting up Woolball client event listeners...');
-  
+
   try {
     woolballClient.on('started', (data) => {
       console.log('Task started:', data);
@@ -186,20 +194,17 @@ function setupEventListeners() {
 
 function notifyPopup(type, data) {
   try {
-    // Adapt message format for simplified interface
     let message;
     if (type === 'taskCompleted') {
       message = { type, task: data.task, timestamp: Date.now() };
     } else if (type === 'connectionStatus') {
       message = { type, connected: data.connected, timestamp: Date.now() };
-    } else if (type === 'woolballStatus') {
-      message = { type, initialized: data.initialized, timestamp: Date.now() };
     } else {
       message = { type, data, timestamp: Date.now() };
     }
-    
+
     console.log('Sending message to popup:', message);
-    
+
     chrome.runtime.sendMessage(message)
       .then(() => {
         console.log('Message sent successfully to popup');
@@ -207,11 +212,11 @@ function notifyPopup(type, data) {
       .catch(error => {
         console.log('Popup not open, storing update in cache:', message);
         pendingUpdates.push(message);
-        
+
         if (pendingUpdates.length > 100) {
           pendingUpdates = pendingUpdates.slice(-100);
         }
-        
+
         chrome.storage.local.set({ pendingUpdates });
       });
   } catch (error) {

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -3,38 +3,65 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=500, initial-scale=1.0">
-  <title>Woolball Client</title>
+  <title>Woolball</title>
   <link rel="stylesheet" href="styles/popup.css">
 </head>
 <body>
   <div class="container">
     <div class="header">
-      <h1>Woolball Client</h1>
-      <p class="subtitle">AI Task Processing</p>
+      <div class="header-title">
+        <svg class="logo" width="28" height="28" viewBox="0 0 100 100" fill="none">
+          <circle cx="50" cy="50" r="44" stroke="#ff9800" stroke-width="4" opacity="0.3"/>
+          <circle cx="50" cy="50" r="30" stroke="#ff9800" stroke-width="3" opacity="0.5"/>
+          <circle cx="50" cy="50" r="16" stroke="#ff9800" stroke-width="2.5" opacity="0.8"/>
+          <circle cx="50" cy="50" r="5" fill="#ff9800"/>
+        </svg>
+        <h1>woolball</h1>
+        <span class="badge">extension</span>
+      </div>
     </div>
-    
+
+    <div class="mode-tabs">
+      <button id="tab-cloud" class="mode-tab active">Cloud</button>
+      <button id="tab-selfhosted" class="mode-tab">Self-hosted</button>
+    </div>
+
+    <div id="cloud-section" class="section">
+      <div class="field">
+        <label for="cloud-api-key">API Key</label>
+        <input type="password" id="cloud-api-key" placeholder="wb_ws_...">
+      </div>
+      <div class="get-key-row">
+        <a href="#" id="get-key-link">Get a key</a>
+      </div>
+      <button id="cloud-connect-btn" class="connect-btn">Connect</button>
+    </div>
+
+    <div id="selfhosted-section" class="section hidden">
+      <div class="field">
+        <label for="selfhosted-url">Server URL</label>
+        <input type="text" id="selfhosted-url" placeholder="ws://localhost:9003/ws">
+      </div>
+      <div class="field">
+        <label for="selfhosted-api-key">API Key <span class="optional">(optional)</span></label>
+        <input type="password" id="selfhosted-api-key" placeholder="wb_ws_...">
+      </div>
+      <button id="selfhosted-connect-btn" class="connect-btn">Connect</button>
+    </div>
+
     <div class="status-container">
       <div class="status-indicator">
         <span id="status-dot" class="status-dot"></span>
         <span id="status-text">Disconnected</span>
       </div>
-      <div class="server-info">
-        <input type="text" id="server-url" placeholder="ws://localhost:9003/ws" value="ws://localhost:9003/ws">
-        <button id="connect-btn">Connect</button>
-      </div>
-      <div class="woolball-status-container">
-        <span id="woolball-status">Woolball not initialized</span>
-      </div>
     </div>
 
     <div class="stats-container">
-      <div class="stat-box centered-stat">
+      <div class="stat-box">
         <span class="stat-label">Processed Tasks</span>
         <span id="tasks-completed" class="stat-value">0</span>
       </div>
     </div>
-
-
   </div>
 
   <script src="popup.js"></script>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,25 +1,69 @@
 const statusDot = document.getElementById('status-dot');
 const statusText = document.getElementById('status-text');
-const serverUrlInput = document.getElementById('server-url');
-const connectBtn = document.getElementById('connect-btn');
-const woolballStatusEl = document.getElementById('woolball-status');
 const tasksCompletedEl = document.getElementById('tasks-completed');
+
+const tabCloud = document.getElementById('tab-cloud');
+const tabSelfhosted = document.getElementById('tab-selfhosted');
+const cloudSection = document.getElementById('cloud-section');
+const selfhostedSection = document.getElementById('selfhosted-section');
+
+const cloudApiKeyInput = document.getElementById('cloud-api-key');
+const cloudConnectBtn = document.getElementById('cloud-connect-btn');
+const getKeyLink = document.getElementById('get-key-link');
+
+const selfhostedUrlInput = document.getElementById('selfhosted-url');
+const selfhostedApiKeyInput = document.getElementById('selfhosted-api-key');
+const selfhostedConnectBtn = document.getElementById('selfhosted-connect-btn');
 
 let isConnected = false;
 let isWoolballInitialized = false;
 let tasksCompleted = 0;
+let currentMode = 'cloud';
 
-document.addEventListener('DOMContentLoaded', async () => {
-  chrome.storage.local.get(['serverUrl'], (result) => {
-    if (result.serverUrl) {
-      serverUrlInput.value = result.serverUrl;
+function isValidServerUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'wss:' || parsed.protocol === 'ws:';
+  } catch {
+    return false;
+  }
+}
+
+function switchMode(mode) {
+  currentMode = mode;
+  chrome.storage.local.set({ mode });
+
+  if (mode === 'cloud') {
+    tabCloud.classList.add('active');
+    tabSelfhosted.classList.remove('active');
+    cloudSection.classList.remove('hidden');
+    selfhostedSection.classList.add('hidden');
+  } else {
+    tabCloud.classList.remove('active');
+    tabSelfhosted.classList.add('active');
+    cloudSection.classList.add('hidden');
+    selfhostedSection.classList.remove('hidden');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.local.get(['mode', 'apiKey', 'serverUrl', 'selfhostedApiKey', 'tasksCompleted', 'isConnected'], (result) => {
+    if (result.mode) {
+      switchMode(result.mode);
     }
-  });
-
-  // Reset task counter when extension is opened
-  resetTaskCounter();
-
-  chrome.storage.local.get(['isConnected'], (result) => {
+    if (result.apiKey) {
+      cloudApiKeyInput.value = result.apiKey;
+    }
+    if (result.serverUrl) {
+      selfhostedUrlInput.value = result.serverUrl;
+    }
+    if (result.selfhostedApiKey) {
+      selfhostedApiKeyInput.value = result.selfhostedApiKey;
+    }
+    if (result.tasksCompleted) {
+      tasksCompleted = result.tasksCompleted;
+      tasksCompletedEl.textContent = tasksCompleted;
+    }
     if (result.isConnected) {
       updateConnectionStatus(true);
       requestPendingUpdates();
@@ -28,115 +72,134 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   chrome.runtime.sendMessage({ action: 'getWoolballStatus' }, (response) => {
     if (response && response.initialized) {
-      updateWoolballStatus(true);
-      
+      isWoolballInitialized = true;
       if (response.connected) {
         updateConnectionStatus(true);
       }
     }
   });
 
-  connectBtn.addEventListener('click', toggleConnection);
+  tabCloud.addEventListener('click', () => switchMode('cloud'));
+  tabSelfhosted.addEventListener('click', () => switchMode('selfhosted'));
+
+  cloudConnectBtn.addEventListener('click', () => handleConnect('cloud'));
+  selfhostedConnectBtn.addEventListener('click', () => handleConnect('selfhosted'));
+
+  getKeyLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    chrome.tabs.create({ url: 'https://portal.woolball.xyz#create-key' });
+  });
 });
 
-// Function removed as initialization is now handled in toggleConnection
-
-function updateWoolballStatus(initialized) {
-  isWoolballInitialized = initialized;
-  
-  if (initialized) {
-    woolballStatusEl.textContent = 'Woolball successfully initialized';
-  } else {
-    woolballStatusEl.textContent = 'Woolball not initialized';
-  }
-}
-
-async function toggleConnection() {
+async function handleConnect(mode) {
   if (isConnected) {
     chrome.runtime.sendMessage({ action: 'disconnect' });
     updateConnectionStatus(false);
-  } else {
-    const serverUrl = serverUrlInput.value.trim();
-    if (!serverUrl) {
-      alert('Please enter a valid server URL');
+    return;
+  }
+
+  let serverUrl;
+  let apiKey;
+
+  if (mode === 'cloud') {
+    apiKey = cloudApiKeyInput.value.trim();
+    if (!apiKey || !apiKey.startsWith('wb_ws_')) {
+      alert('Please enter a valid API key (starts with wb_ws_)');
       return;
     }
-    
-    chrome.storage.local.set({ serverUrl });
-    
-    statusDot.classList.remove('connected');
-    statusDot.classList.add('connecting');
-    statusText.textContent = 'Connecting...';
-    connectBtn.disabled = true;
-    woolballStatusEl.textContent = 'Initializing Woolball...';
-    
-    // Initialize Woolball first if needed
-    if (!isWoolballInitialized) {
-      try {
-        await new Promise((resolve, reject) => {
-          chrome.runtime.sendMessage({ action: 'initWoolball' }, (response) => {
-            if (response && response.success) {
-              updateWoolballStatus(true);
-              resolve();
-            } else {
-              reject(new Error(response?.error || 'Failed to initialize Woolball'));
-            }
-          });
-        });
-      } catch (error) {
-        statusDot.classList.remove('connecting');
-        statusText.textContent = 'Connection failed';
-        connectBtn.disabled = false;
-        woolballStatusEl.textContent = 'Woolball initialization failed';
-        alert(`Failed to initialize Woolball: ${error.message}`);
-        return;
-      }
+    serverUrl = 'wss://api.woolball.xyz/ws';
+    chrome.storage.local.set({ apiKey });
+  } else {
+    serverUrl = selfhostedUrlInput.value.trim();
+    if (!serverUrl) {
+      serverUrl = 'ws://localhost:9003/ws';
+      selfhostedUrlInput.value = serverUrl;
     }
-    
-    // Now connect to the server
-    chrome.runtime.sendMessage(
-      { action: 'connect', serverUrl },
-      (response) => {
-        if (response && response.success) {
-          updateConnectionStatus(true);
-        } else {
-          statusDot.classList.remove('connecting');
-          statusText.textContent = 'Connection failed';
-          connectBtn.disabled = false;
-          
-          if (response && response.error) {
-            alert(`Connection failed: ${response.error}`);
+    if (!isValidServerUrl(serverUrl)) {
+      alert('Please enter a valid WebSocket URL (ws:// or wss://)');
+      return;
+    }
+    apiKey = selfhostedApiKeyInput.value.trim() || null;
+    chrome.storage.local.set({ serverUrl });
+    if (apiKey) {
+      chrome.storage.local.set({ selfhostedApiKey: apiKey });
+    }
+  }
+
+  const connectBtn = mode === 'cloud' ? cloudConnectBtn : selfhostedConnectBtn;
+
+  statusDot.classList.remove('connected');
+  statusDot.classList.add('connecting');
+  statusText.textContent = 'Connecting...';
+  connectBtn.disabled = true;
+
+  if (!isWoolballInitialized) {
+    try {
+      await new Promise((resolve, reject) => {
+        chrome.runtime.sendMessage({ action: 'initWoolball' }, (response) => {
+          if (response && response.success) {
+            isWoolballInitialized = true;
+            resolve();
+          } else {
+            reject(new Error(response?.error || 'Failed to initialize Woolball'));
           }
+        });
+      });
+    } catch (error) {
+      statusDot.classList.remove('connecting');
+      statusText.textContent = 'Failed';
+      connectBtn.disabled = false;
+      alert('Woolball initialization failed: ' + error.message);
+      return;
+    }
+  }
+
+  chrome.runtime.sendMessage(
+    { action: 'connect', serverUrl, apiKey },
+    (response) => {
+      if (response && response.success) {
+        updateConnectionStatus(true);
+      } else {
+        statusDot.classList.remove('connecting');
+        statusText.textContent = 'Failed';
+        connectBtn.disabled = false;
+        if (response && response.error) {
+          alert('Connection failed: ' + response.error);
         }
       }
-    );
-  }
+    }
+  );
 }
 
 function updateConnectionStatus(connected) {
   isConnected = connected;
   chrome.storage.local.set({ isConnected });
-  
+
+  const connectBtn = currentMode === 'cloud' ? cloudConnectBtn : selfhostedConnectBtn;
+
   if (connected) {
     statusDot.classList.remove('connecting');
     statusDot.classList.add('connected');
     statusText.textContent = 'Connected';
-    connectBtn.textContent = 'Disconnect';
-    connectBtn.classList.add('disconnect');
-    connectBtn.disabled = false;
+    cloudConnectBtn.textContent = 'Disconnect';
+    cloudConnectBtn.classList.add('disconnect');
+    cloudConnectBtn.disabled = false;
+    selfhostedConnectBtn.textContent = 'Disconnect';
+    selfhostedConnectBtn.classList.add('disconnect');
+    selfhostedConnectBtn.disabled = false;
   } else {
     statusDot.classList.remove('connected', 'connecting');
     statusText.textContent = 'Disconnected';
-    connectBtn.textContent = 'Connect';
-    connectBtn.classList.remove('disconnect');
-    connectBtn.disabled = false;
+    cloudConnectBtn.textContent = 'Connect';
+    cloudConnectBtn.classList.remove('disconnect');
+    cloudConnectBtn.disabled = false;
+    selfhostedConnectBtn.textContent = 'Connect';
+    selfhostedConnectBtn.classList.remove('disconnect');
+    selfhostedConnectBtn.disabled = false;
   }
 }
 
-
-
 function addTaskToHistory(task) {
-  // Increment task counter only once per task
   tasksCompleted++;
   tasksCompletedEl.textContent = tasksCompleted;
   chrome.storage.local.set({ tasksCompleted });
@@ -145,8 +208,6 @@ function addTaskToHistory(task) {
 function requestPendingUpdates() {
   chrome.runtime.sendMessage({ action: 'getPendingUpdates' }, (response) => {
     if (response && response.updates && response.updates.length > 0) {
-      console.log(`Processing ${response.updates.length} pending updates`);
-      
       response.updates.forEach(update => {
         processMessage(update);
       });
@@ -156,16 +217,12 @@ function requestPendingUpdates() {
 
 function processMessage(message) {
   if (!message || !message.type) return;
-  
+
   switch (message.type) {
     case 'connectionStatus':
       updateConnectionStatus(message.connected);
       break;
-    case 'woolballStatus':
-      updateWoolballStatus(message.initialized);
-      break;
     case 'taskCompleted':
-      // Task count is incremented in addTaskToHistory
       if (message.task) {
         addTaskToHistory(message.task);
       }
@@ -176,13 +233,3 @@ function processMessage(message) {
 chrome.runtime.onMessage.addListener((message) => {
   processMessage(message);
 });
-
-// Reset task counter when extension is opened
-function resetTaskCounter() {
-  chrome.storage.local.get(['tasksCompleted'], (result) => {
-    if (result.tasksCompleted) {
-      tasksCompleted = result.tasksCompleted;
-      tasksCompletedEl.textContent = tasksCompleted;
-    }
-  });
-}

--- a/chrome-extension/styles/popup.css
+++ b/chrome-extension/styles/popup.css
@@ -1,6 +1,3 @@
-/* Estilos para o popup da extensão Woolball */
-
-/* Estilos gerais */
 * {
   box-sizing: border-box;
   margin: 0;
@@ -8,212 +5,266 @@
 }
 
 html {
-  width: 500px !important;
-  min-width: 500px !important;
+  width: 380px !important;
+  min-width: 380px !important;
 }
 
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  font-size: 14px;
-  color: #333;
-  background-color: #f5f5f5;
-  width: 500px !important;
-  min-width: 500px !important;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 13px;
+  color: #e0e0e0;
+  background-color: #0a0a0a;
+  width: 380px !important;
+  min-width: 380px !important;
   height: auto;
   overflow-y: auto;
 }
 
 .container {
-  padding: 15px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
+  gap: 14px;
 }
 
-/* Cabeçalho */
+/* Header */
 .header {
   text-align: center;
-  margin-bottom: 15px;
-  padding-bottom: 10px;
-  border-bottom: 1px solid #ddd;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #1e1e1e;
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 .header h1 {
-  font-size: 20px;
-  margin-bottom: 5px;
-  color: #2c3e50;
+  font-size: 18px;
+  font-weight: 600;
+  color: #e0e0e0;
+  letter-spacing: -0.3px;
 }
 
-.subtitle {
-  font-size: 12px;
-  color: #7f8c8d;
+.badge {
+  font-size: 10px;
+  font-weight: 500;
+  color: #ff9800;
+  background: rgba(255, 152, 0, 0.12);
+  border: 1px solid rgba(255, 152, 0, 0.25);
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
-/* Container de status */
-.status-container {
-  background-color: #fff;
+.logo {
+  flex-shrink: 0;
+}
+
+/* Mode Tabs */
+.mode-tabs {
+  display: flex;
+  background: #141414;
   border-radius: 8px;
-  padding: 12px;
-  margin-bottom: 15px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 3px;
+  border: 1px solid #1e1e1e;
+}
+
+.mode-tab {
+  flex: 1;
+  padding: 8px 0;
+  border: none;
+  background: transparent;
+  color: #888;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+}
+
+.mode-tab:hover {
+  color: #bbb;
+}
+
+.mode-tab.active {
+  background: #1e1e1e;
+  color: #e0e0e0;
+}
+
+/* Sections */
+.section {
+  background: #141414;
+  border: 1px solid #1e1e1e;
+  border-radius: 8px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section.hidden {
+  display: none;
+}
+
+/* Fields */
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #888;
+}
+
+.optional {
+  color: #555;
+  font-weight: 400;
+}
+
+.field input {
+  padding: 8px 10px;
+  background: #1e1e1e;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 13px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.field input::placeholder {
+  color: #555;
+}
+
+.field input:focus {
+  border-color: #ff9800;
+}
+
+/* Get key link */
+.get-key-row {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.get-key-row a {
+  font-size: 12px;
+  color: #ff9800;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.get-key-row a:hover {
+  color: #ffa726;
+  text-decoration: underline;
+}
+
+/* Connect button */
+.connect-btn {
+  padding: 9px 0;
+  background: #ff9800;
+  color: #0a0a0a;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.connect-btn:hover {
+  background: #ffa726;
+}
+
+.connect-btn.disconnect {
+  background: #ef5350;
+  color: #fff;
+}
+
+.connect-btn.disconnect:hover {
+  background: #f44336;
+}
+
+.connect-btn:disabled {
+  background: #2a2a2a;
+  color: #555;
+  cursor: not-allowed;
+}
+
+/* Status */
+.status-container {
+  display: flex;
+  justify-content: center;
 }
 
 .status-indicator {
   display: flex;
   align-items: center;
-  margin-bottom: 10px;
+  gap: 8px;
 }
 
 .status-dot {
-  width: 12px;
-  height: 12px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  background-color: #e74c3c;
-  margin-right: 8px;
+  background-color: #ef5350;
   display: inline-block;
 }
 
 .status-dot.connected {
-  background-color: #2ecc71;
+  background-color: #4caf50;
 }
 
 .status-dot.connecting {
-  background-color: #f39c12;
+  background-color: #ff9800;
   animation: pulse 1.5s infinite;
 }
 
 @keyframes pulse {
-  0% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-  100% {
-    opacity: 1;
-  }
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
 }
 
-.server-info {
-  display: flex;
-  margin-bottom: 10px;
-}
-
-#server-url {
-  flex: 1;
-  padding: 8px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  margin-right: 8px;
+#status-text {
   font-size: 12px;
+  color: #888;
 }
 
-#connect-btn {
-  padding: 8px 12px;
-  background-color: #3498db;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.3s;
-}
-
-#connect-btn:hover {
-  background-color: #2980b9;
-}
-
-#connect-btn.disconnect {
-  background-color: #e74c3c;
-}
-
-#connect-btn.disconnect:hover {
-  background-color: #c0392b;
-}
-
-#connect-btn:disabled {
-  background-color: #95a5a6;
-  cursor: not-allowed;
-}
-
-.woolball-control {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-#init-woolball-btn {
-  padding: 6px 10px;
-  background-color: #9b59b6;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.3s;
-  font-size: 12px;
-}
-
-#init-woolball-btn:hover {
-  background-color: #8e44ad;
-}
-
-#init-woolball-btn.initialized {
-  background-color: #27ae60;
-}
-
-#init-woolball-btn.initialized:hover {
-  background-color: #219653;
-}
-
-#init-woolball-btn:disabled {
-  background-color: #95a5a6;
-  cursor: not-allowed;
-}
-
-#woolball-status {
-  font-size: 12px;
-  color: #7f8c8d;
-  margin-left: 10px;
-  flex: 1;
-  text-align: right;
-}
-
-/* Container de estatísticas */
+/* Stats */
 .stats-container {
   display: flex;
   justify-content: center;
-  margin-bottom: 15px;
 }
 
 .stat-box {
-  flex: 0 0 auto;
-  background-color: #fff;
+  background: #141414;
+  border: 1px solid #1e1e1e;
   border-radius: 8px;
-  padding: 15px 30px;
+  padding: 12px 24px;
   text-align: center;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.centered-stat {
-  width: 80%;
-  max-width: 300px;
+  width: 100%;
 }
 
 .stat-label {
   display: block;
-  font-size: 14px;
-  color: #7f8c8d;
-  margin-bottom: 8px;
+  font-size: 11px;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
 }
 
 .stat-value {
   display: block;
-  font-size: 24px;
-  font-weight: bold;
-  color: #2c3e50;
-}
-
-/* Responsividade */
-@media (max-width: 400px) {
-  body {
-    width: 100%;
-  }
+  font-size: 28px;
+  font-weight: 700;
+  color: #e0e0e0;
 }

--- a/src/providers/Woolball.ts
+++ b/src/providers/Woolball.ts
@@ -66,6 +66,10 @@ class Woolball {
         });
     }
 
+    public setWsUrl(url: string): void {
+        this.wsUrl = url;
+    }
+
     public start(): void {
         if (this.wsConnection) {
             console.warn('WebSocket connection already exists');


### PR DESCRIPTION
## Summary

- Add public `setWsUrl()` method to the `Woolball` class (per `.claude/rules/chrome-extension.md`)
- Redesign extension popup with **Cloud** and **Self-hosted** tabs + dark theme
- Cloud mode connects to `wss://api.woolball.xyz/ws` with a `wb_ws_` API key
- Self-hosted mode preserves the `ws://localhost:9003/ws` workflow with an optional API key
- API key is embedded in the clientId query param (`?key=`) for gateway-side auth
- "Get a key" link opens `portal.woolball.xyz#create-key` to auto-open the create key modal
- URL validation for WebSocket addresses (`ws://` / `wss://`)

**Companion changes** (already pushed to main):
- **woolball-gateway**: WS API key auth fallback in `AuthenticateAsync()` via existing `ApiKeyService`
- **woolball-portal**: `#create-key` hash deep-link to auto-open `CreateKeyModal`

## Test plan

- [ ] Extension Cloud mode: enter valid WS key → connects to production gateway
- [ ] Extension Self-hosted mode: enter `ws://localhost:9003/ws` without key → connects directly
- [ ] Extension Self-hosted + key: custom gateway URL + key → connects with auth
- [ ] "Get a key" button opens portal with create key modal auto-opened
- [ ] Gateway: `wscat -c "wss://api.woolball.xyz/ws/test?key=wb_ws_valid"` → connects (401 without key)
- [ ] Build: `npm run build && npm run build:extension`

🤖 Generated with [Claude Code](https://claude.com/claude-code)